### PR TITLE
edit README after docker being mandatory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 ligo_compiler=docker run --rm -v "$(PWD)":"$(PWD)" -w "$(PWD)" ligolang/ligo:stable
 PROTOCOL_OPT=
-# ^ use LIGO en var bin if configured, otherwise use docker
+# ^ fill-in to test new features, see "Protocol Upgrades" section on https://ligolang.org documentation
 
 project_root=--project-root .
 # ^ required when using packages

--- a/README.md
+++ b/README.md
@@ -20,15 +20,9 @@ see [example `FA2` in the test directory](./test/bootstrap/single_asset.mligo).
 ## Requirements
 
 The contract is written in `cameligo` flavour of [LigoLANG](https://ligolang.org/),
-to be able to compile the contract, you need either:
+to be able to compile the contract, you need [docker](https://docs.docker.com/engine/install/).
 
-- a [ligo binary](https://ligolang.org/docs/intro/installation#static-linux-binary),
-  in this case, to use the binary, you need to have set up a `LIGO` environment variable,
-  pointing to the binary (see [Makefile](./Makefile))
-- or [docker](https://docs.docker.com/engine/install/)
-
-For deploy scripts, you also need to have [nodejs](https://nodejs.org/en/) installed,
-up to version 14 and docker if you wish to deploy on a sandbox.
+For deploy scripts, you also need to have [nodejs](https://nodejs.org/en/) installed, up to version 14.
 
 ## Usage
 


### PR DESCRIPTION
Hello here is  a small edition after docker now mandatory (see https://github.com/ligolang/dao-cameligo/commit/f9fd1374f2e80af6cb519ccad22721ad8f8beaae)